### PR TITLE
Disable selector-attribute-quotes rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ module.exports = {
 		// 'selector-attribute-operator-space-after': 'never'
 		// 'selector-attribute-operator-space-before': 'never'
 
-		'selector-attribute-quotes': 'always',
+		'selector-attribute-quotes': 'never',
 		'selector-combinator-space-after': null,
 		'selector-combinator-space-before': null,
 		'selector-descendant-combinator-no-non-space': null,


### PR DESCRIPTION
this is automatically fixed by prettier

Generally speaking, what exactly is a valid reason to set any rule to "always" in this plugin?