### PR TITLE
Stop disabling 2 unrelated rules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,8 +34,6 @@ module.exports = {
 		'declaration-block-semicolon-newline-before': null,
 		'declaration-block-semicolon-space-after': null,
 		'declaration-block-semicolon-space-before': null,
-		'declaration-block-no-redundant-longhand-properties': null,
-		'declaration-block-no-shorthand-property-overrides': null,
 
 		// prettier always adds the trailing semicolon
 		'declaration-block-trailing-semicolon': null,


### PR DESCRIPTION
Both of these rules ([1](https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties/), [2](https://stylelint.io/user-guide/rules/declaration-block-no-shorthand-property-overrides/)) are semantic and aren't formatted by prettier.

[Prettier playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBDABMAOld6C2qATgOYCWUAtDBAA5LoCMtAHgNw56GkWVFkkAFjAYAmVh1wFi5KgCMIMGvgYBmCZ2k8qAGzgAzEegAsGqAF8cIADQg6MMtADOyUMSIQA7gAViCFyioAG4QZAAmNiByRKhgANZwMADKtLEUJMgwRACucLbC+DoA6oJk8E6pYHBJ-mVkQWUAnsjgTi62FE5wRDDeMSSEyPqoOl22AFZOLABCMfGJSaj4cAAyFHBDI2MgkyxJ6XoAitmKG0jDo3kgqURdRC1gbZG0-LBF4TCCyAAcAAy2LwgXSKMVoLRecDuQQ2tiIcAAjtkyHC+qgBqhNpdbF18GRMjkrk4DnBjqdMdsYKg5O8wp9kKJbFlUGQdOkAMIQfCDFBQaAwkDZLoAFSpAQuXXM5iAA) with the first invalid example of the first rule.