### PR TITLE
Added stylelint@10 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "*.md"
   ],
   "peerDependencies": {
-    "stylelint": "^9.1.1"
+    "stylelint": "^9.1.1 || ^10.0.0"
   },
   "devDependencies": {
     "blue-tape": "^1.0.0",


### PR DESCRIPTION
As [stylelint v10](https://github.com/stylelint/stylelint/releases/tag/10.0.0) was released recently, this PR updates the peer dependency so we can use this package with it.

If you want me to update the version check to be `"prettier": ">= 9.1.1"` then just let know 👍 