### PR TITLE
Remove '$' from the script in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Turns off all rules that are unnecessary or might conflict with Prettier. This l
 Install `stylelint-config-prettier`:
 
 ```
-$ npm install --save-dev stylelint-config-prettier
+npm install --save-dev stylelint-config-prettier
 ```
 
 Then, append `stylelint-config-prettier` to the [`extends` array](https://stylelint.io/user-guide/configuration/#extends) in your `.stylelintrc.*` file. Make sure to put it **last,** so it will override other configs.


### PR DESCRIPTION
With the GitHub built-in way to copy a script by clicking a button, the '$' sign is preventing the copied script from being used out-of-the-box. Removing the sign should make it more useful.

<img width="480" alt="Screen Shot 2021-07-02 at 14 17 17" src="https://user-images.githubusercontent.com/7040242/124224269-4c559880-db40-11eb-8be1-e39da4b67b89.png">