### PR TITLE
Add stylelint-scss rules

### DIFF
--- a/src/checker.js
+++ b/src/checker.js
@@ -17,10 +17,17 @@ function check(path) {
 			const configRules = config.config.rules;
 			const conflictingRules = [];
 
+			function isEmpty(value) {
+				return (
+					value === null ||
+					(Array.isArray(value) && value.length === 0)
+				);
+			}
+
 			Object.keys(prettierRules).forEach((rule) => {
 				if (
 					hasOwnProperty.call(configRules, rule) &&
-					configRules[rule] !== null &&
+					!isEmpty(configRules[rule]) &&
 					configRules[rule][0] !== prettierRules[rule]
 				) {
 					conflictingRules.push(rule);

--- a/src/index.js
+++ b/src/index.js
@@ -124,5 +124,20 @@ module.exports = {
 
 		// prettier has its own quotes rule
 		'string-quotes': null,
+
+		'scss/at-else-closing-brace-newline-after': null,
+		'scss/at-else-closing-brace-space-after': null,
+		'scss/at-else-empty-line-before': null,
+		'scss/at-else-if-parentheses-space-before': null,
+		'scss/at-function-parentheses-space-before': null,
+		'scss/at-if-closing-brace-newline-after': null,
+		'scss/at-if-closing-brace-space-after': null,
+		'scss/at-mixin-parentheses-space-before': null,
+		'scss/dollar-variable-colon-newline-after': null,
+		'scss/dollar-variable-colon-space-after': null,
+		'scss/dollar-variable-colon-space-before': null,
+		'scss/operator-no-newline-after': null,
+		'scss/operator-no-newline-before': null,
+		'scss/operator-no-unspaced': null,
 	},
 };


### PR DESCRIPTION
This PR disables rules from the stylelint-scss plugin that are unnecessary or might conflict with Prettier, closes #105. These rules are included within in main config rather than a seperate config and matches eslint-config-prettier. If the user does not have any scss rules configured they are ignored, therefore we don't need to introduce stylelint-scss as a peer dependency.

To enable support I've had to modify the checker as if a stylelint-scss rule is set to `null` in the users config i.e disabled, stylelint-scss reports the setting as an empty array rather than null. Therefore I've updated the script to check for both null and an empty array.