### PR TITLE
fix adding at-rule-empty-line-before again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ module.exports = {
 		indentation: null,
 		linebreaks: null,
 
+		'at-rule-empty-line-before': null,
 		'at-rule-name-case': null,
 		'at-rule-name-newline-after': null,
 		'at-rule-name-space-after': null,


### PR DESCRIPTION
https://github.com/prettier/stylelint-config-prettier/issues/128

This readds the now missing rule `at-rule-empty-line-before`. As mentioned in the commit message, this is conflicting with prettier now in instances where @if / @else is being used.

I was able to make stylelint and prettier in my project pass by adding the rule there manually again.