### PR TITLE
Fix conflicts with range operators in media features

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,8 @@ module.exports = {
 		'media-feature-colon-space-before': null,
 		'media-feature-name-case': null,
 		'media-feature-parentheses-space-inside': null,
+		'media-feature-range-operator-space-after': null,
+		'media-feature-range-operator-space-before': null,
 		'media-query-list-comma-newline-after': null,
 		'media-query-list-comma-newline-before': null,
 		'media-query-list-comma-space-after': null,


### PR DESCRIPTION
Fixes conflicts with range operators in media features by turning off:

- [`media-feature-range-operator-space-after`](https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after/)
- [`media-feature-range-operator-space-before`](https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before/)

Example of range context:

```css
@media (width >= 600px) {}
```

[Prettier playground link](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEABAtnAJgSwIYAEAFAO45YwAWBNAfDTQCwAMc6AlAcADpQC+vXhmz5iAJlboGNADwBeaWQrU60lm049+vEABoQEAA4wc0AM7JQeAE7WIJAAo2EFlHgA2JPAE8L+gEbWeGAA1nAwAMp4mAAyOFBwyABmHmZwAUGh4RGGwfEA5sgw1gCu6SBs-thY2DF4UPklePlwAGIQ1uh4MCYNyCB4JTAQeiCUMOjuAOqUOPBmuWBwES5zOABuc979YGZ+IPFp1jAOQfldyanlAFZmAB4RBe5wAIolEPCX7mn6udZHOz2o0M1niMCm5CoyAAHMxfnY0lMgoZ+iC4Ed1ol9ABHd7wU5GVwDMwAWgS2Gwo2scFxOGpp2aFyQKW+5TS6BwRVKbKerzxiWZV30MDw-ghymQYmFQRw7gKAGEIOgmRUzABWUYlNIAFVFrhZPxA6zKAEkoDVYBEwKDjABBc0RGDeZ5fNJ8PhAA) - showing Prettier formatting it.