### PR TITLE
Remove commented out SCSS rules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,21 +78,5 @@ module.exports = {
 		'value-list-comma-space-after': null,
 		'value-list-comma-space-before': null,
 		'value-list-max-empty-lines': null,
-
-		// TODO: https://github.com/prettier/stylelint-config-prettier/issues/127
-		// 'scss/at-else-closing-brace-newline-after': null,
-		// 'scss/at-else-closing-brace-space-after': null,
-		// 'scss/at-else-empty-line-before': null,
-		// 'scss/at-else-if-parentheses-space-before': null,
-		// 'scss/at-function-parentheses-space-before': null,
-		// 'scss/at-if-closing-brace-newline-after': null,
-		// 'scss/at-if-closing-brace-space-after': null,
-		// 'scss/at-mixin-parentheses-space-before': null,
-		// 'scss/dollar-variable-colon-newline-after': null,
-		// 'scss/dollar-variable-colon-space-after': null,
-		// 'scss/dollar-variable-colon-space-before': null,
-		// 'scss/operator-no-newline-after': null,
-		// 'scss/operator-no-newline-before': null,
-		// 'scss/operator-no-unspaced': null,
 	},
 };


### PR DESCRIPTION
No longer needed now that `https://github.com/prettier/stylelint-config-prettier-scss` exists. :-)